### PR TITLE
Change dependency from gymnax to stable-gymnax

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ grads, obs_seq, grad_accumulator = get_saliency_maps(rng, model, config)
 vis_fn(grads, obs_seq, config, use_latex=False)
 ```
 ## Other Useful Libraries
-- [`gymnax`](https://github.com/RobertTLange/gymnax) - The `jax`-capable `gymnasium` API we built upon
+- [`gymnax`](https://github.com/RobertTLange/gymnax) - The (deprecated) `jax`-capable `gymnasium` API
+- [`stable-gymnax`](https://github.com/smorad/stable-gymnax) - A maintained and patched version of `gymnax`
 - [`popgym`](https://github.com/proroklab/popgym) - The original collection of POMDPs, implemented in `numpy`
 - [`popjaxrl`](https://github.com/luchris429/popjaxrl) - A `jax` version of `popgym`
 - [`popjym`](https://github.com/EdanToledo/popjym) - A more readable version of `popjaxrl` environments that served as a basis for our work

--- a/popgym_arcade/environments/autoencode.py
+++ b/popgym_arcade/environments/autoencode.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 import chex
 import jax
 import jax.numpy as jnp
-from flax import struct
+from chex import dataclass
 from jax import lax
 import functools
 from gymnax.environments import environment, spaces
@@ -16,7 +16,7 @@ from popgym_arcade.environments.draw_utils import (draw_heart,
                                             draw_sub_canvas)
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:
     timestep: int
     cards: chex.Array
@@ -25,7 +25,7 @@ class EnvState:
     default_action: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     pass
 

--- a/popgym_arcade/environments/battleship.py
+++ b/popgym_arcade/environments/battleship.py
@@ -7,7 +7,7 @@ from jax import lax
 from jax import random
 import jax.numpy as jnp
 import numpy as np
-from flax import struct
+from chex import dataclass
 from gymnax.environments import environment, spaces
 from popgym_arcade.environments.draw_utils import (draw_rectangle,
                                             draw_x,
@@ -92,7 +92,7 @@ def generate_random_board(rng, board_size, ship_sizes):
     return board
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:
     action_x: chex.Array
     action_y: chex.Array
@@ -104,7 +104,7 @@ class EnvState:
     timestep: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     pass
 

--- a/popgym_arcade/environments/cartpole.py
+++ b/popgym_arcade/environments/cartpole.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Tuple, Union
 
 import chex
-from flax import struct
+from chex import dataclass
 import jax
 from jax import lax
 import jax.numpy as jnp
@@ -9,6 +9,7 @@ import functools
 import time
 from gymnax.environments import environment
 from gymnax.environments import spaces
+from chex import dataclass
 
 from popgym_arcade.environments.draw_utils import (draw_crooked_arrow,
                                             draw_horizontal_arrow,
@@ -19,7 +20,8 @@ from popgym_arcade.environments.draw_utils import (draw_crooked_arrow,
                                             draw_str)
 
 
-@struct.dataclass
+@dataclass(frozen=True)
+
 class EnvState(environment.EnvState):
     x: chex.Array
     x_dot: chex.Array
@@ -29,7 +31,7 @@ class EnvState(environment.EnvState):
     time: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams(environment.EnvParams):
     gravity: float = 9.8
     masscart: float = 1.0

--- a/popgym_arcade/environments/cartpole.py
+++ b/popgym_arcade/environments/cartpole.py
@@ -21,7 +21,6 @@ from popgym_arcade.environments.draw_utils import (draw_crooked_arrow,
 
 
 @dataclass(frozen=True)
-
 class EnvState(environment.EnvState):
     x: chex.Array
     x_dot: chex.Array

--- a/popgym_arcade/environments/countrecall.py
+++ b/popgym_arcade/environments/countrecall.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, Union
 import chex
 import jax
 import jax.numpy as jnp
-from flax import struct
+from chex import dataclass
 from gymnax.environments import environment, spaces
 import functools
 from jax import lax
@@ -17,7 +17,7 @@ from popgym_arcade.environments.draw_utils import (draw_rectangle,
                                             draw_sub_canvas)
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:    
     timestep: int
     value_cards: chex.Array
@@ -30,7 +30,7 @@ class EnvState:
     alreadyMove: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     pass
 

--- a/popgym_arcade/environments/minesweeper.py
+++ b/popgym_arcade/environments/minesweeper.py
@@ -5,7 +5,7 @@ import chex
 import jax
 import jax.numpy as jnp
 from jax import lax
-from flax import struct
+from chex import dataclass
 from gymnax.environments import environment, spaces
 
 from popgym_arcade.environments.draw_utils import (draw_rectangle,
@@ -16,7 +16,7 @@ from popgym_arcade.environments.draw_utils import (draw_rectangle,
                                             draw_single_digit)
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:
     """
     - mine_grid:
@@ -34,7 +34,7 @@ class EnvState:
     viewed_count: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     pass
 

--- a/popgym_arcade/environments/navigator.py
+++ b/popgym_arcade/environments/navigator.py
@@ -6,7 +6,7 @@ import jax
 from jax import lax
 import jax.numpy as jnp
 import numpy as np
-from flax import struct
+from chex import dataclass
 from gymnax.environments import environment, spaces
 from popgym_arcade.environments.draw_utils import (draw_str,
                                             draw_hexagon,
@@ -104,7 +104,7 @@ def generate_random_tnt_board(
     return board
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvState:
     action_x: chex.Array
     action_y: chex.Array
@@ -113,7 +113,7 @@ class EnvState:
     score: int
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class EnvParams:
     pass
 

--- a/popgym_arcade/wrappers.py
+++ b/popgym_arcade/wrappers.py
@@ -2,7 +2,6 @@ import jax
 import jax.numpy as jnp
 import chex
 import numpy as np
-from flax import struct
 from functools import partial
 from typing import Optional, Tuple, Union, Any
 from gymnax.environments import environment, spaces
@@ -19,7 +18,7 @@ class GymnaxWrapper(object):
         return getattr(self._env, name)
 
 
-@struct.dataclass
+@dataclass(frozen=True)
 class LogEnvState:
     env_state: environment.EnvState
     episode_returns: float

--- a/popgym_arcade/wrappers.py
+++ b/popgym_arcade/wrappers.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import chex
+from chex import dataclass
 import numpy as np
 from functools import partial
 from typing import Optional, Tuple, Union, Any
@@ -39,7 +40,14 @@ class LogWrapper(GymnaxWrapper):
             self, key: chex.PRNGKey, params: Optional[environment.EnvParams] = None
     ) -> Tuple[chex.Array, environment.EnvState]:
         obs, env_state = self._env.reset(key, params)
-        state = LogEnvState(env_state, 0.0, 0, 0.0, 0, 0)
+        state = LogEnvState(
+            env_state=env_state, 
+            episode_returns=0.0, 
+            episode_lengths=0, 
+            returned_episode_returns=0.0, 
+            returned_episode_lengths=0, 
+            timestep=0
+        )
         return obs, state
 
     @partial(jax.jit, static_argnums=(0,))

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
     url="",
     packages=find_packages(),
     install_requires=[
-        "gymnax",
+        # gymnax does not work with newest version of jax
+        # use stable-gymnax alternative
+        "gymnax @ git+ssh://git@github.com/smorad/stable-gymnax.git",
         "dm_pix",
         "jaxtyping",
     ],


### PR DESCRIPTION
`gymnax` is no longer maintained, and breaks with the latest version of `jax`. Update our code to use `stable-gymnax`, which is a maintained version of `gymnax` that works with the most recent `jax` library.