### PR TITLE
Fix observation_space() to use self.obs_size instead of hardcoded values

### DIFF
--- a/popgym_arcade/environments/autoencode.py
+++ b/popgym_arcade/environments/autoencode.py
@@ -197,6 +197,7 @@ class AutoEncode(environment.Environment):
         obs_size: int = 128,
     ):
         super().__init__()
+        self.obs_size = obs_size
         self.partial_obs = partial_obs
         self.num_suits = 4
         self.decksize = 26

--- a/popgym_arcade/environments/autoencode.py
+++ b/popgym_arcade/environments/autoencode.py
@@ -469,7 +469,7 @@ class AutoEncode(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
 
 class AutoEncodeEasy(AutoEncode):

--- a/popgym_arcade/environments/battleship.py
+++ b/popgym_arcade/environments/battleship.py
@@ -579,7 +579,7 @@ class BattleShip(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
 
 class BattleShipEasy(BattleShip):

--- a/popgym_arcade/environments/countrecall.py
+++ b/popgym_arcade/environments/countrecall.py
@@ -258,6 +258,7 @@ class CountRecall(environment.Environment):
         partial_obs: bool = False,
         obs_size: int = 128,
     ):
+        self.obs_size = obs_size
         self.partial_obs = partial_obs
         self.decksize = 26
         self.num_decks = num_decks

--- a/popgym_arcade/environments/countrecall.py
+++ b/popgym_arcade/environments/countrecall.py
@@ -513,7 +513,7 @@ class CountRecall(environment.Environment):
 
     def observation_space(self, params: EnvParams) -> spaces.Box:
         """Observation space of the environment."""
-        return spaces.Box(0, 255, (256, 256, 3), dtype=jnp.uint8)
+        return spaces.Box(0, 255, (self.obs_size, self.obs_size, 3), dtype=jnp.uint8)
 
 
 class CountRecallEasy(CountRecall):

--- a/popgym_arcade/environments/minesweeper.py
+++ b/popgym_arcade/environments/minesweeper.py
@@ -477,7 +477,7 @@ class MineSweeper(environment.Environment):
             # jnp.ones((self.num_mines,)),
             0,
             255,
-            (self.board_size, self.board_size, 3),
+            (self.obs_size, self.obs_size, 3),
             dtype=jnp.uint8,
         )
 


### PR DESCRIPTION
CountRecall, AutoEncode, and BattleShip had hardcoded (256, 256, 3) shapes while MineSweeper incorrectly used self.board_size. All four now use self.obs_size to match the actual observations produced by get_obs().